### PR TITLE
Fix double translation of radio button labels

### DIFF
--- a/Classes/View/Marker.php
+++ b/Classes/View/Marker.php
@@ -1623,6 +1623,7 @@ class Marker
 									foreach ($itemArray as $key => $confArray) {
 										$value = $confArray[1];
 										$label = LocalizationUtility::translate($confArray[0], $this->extensionName);
+										$label = $label ?: $confArray[0];
 										$label = htmlspecialchars($label, ENT_QUOTES, $charset);
 										$itemOut = '<input type="radio"'
 											. CssUtility::classParam($this->prefixId, 'radio')


### PR DESCRIPTION
LocalizationUtility::translate() returned an empty string, when labels are translated in line 1538 before. Check for empty string and use existing translations in the same way like it's done for checkboxes and select boxes.
